### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [2.0.1](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.0.0...v2.0.1) (2025-07-31)
+
+
+### Bug Fixes
+
+* fixing a thing ([67bcbe3](https://github.com/dabernathy89/gf-workflow-testing/commit/67bcbe3785f0554b0c266344296c22f11f2013d5))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-workflow-test",
-            "version": "2.0",
+            "version": "2.0.1",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "private": true,
     "type": "module",
-    "dependencies": {
-    },
+    "dependencies": {},
     "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^12.0.0",


### PR DESCRIPTION
🚀 Release v2.0.1

This PR contains the release branch for version 2.0.1.

## Changes
- Version bumped to 2.0.1
- Changelog updated
- Tag v2.0.1 created

## Semantic Release Output
- Version: 2.0.1
- Tag: v2.0.1
- Changelog generated

Ready for review and merge to main.