### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [2.2.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.1.0...v2.2.0) (2025-08-01)
+
+
+### Features
+
+* feature A ([#10](https://github.com/dabernathy89/gf-workflow-testing/issues/10)) ([12267e0](https://github.com/dabernathy89/gf-workflow-testing/commit/12267e09876ca903c89edc121b5c8f79816823e8))
+* feature B ([#11](https://github.com/dabernathy89/gf-workflow-testing/issues/11)) ([26437e7](https://github.com/dabernathy89/gf-workflow-testing/commit/26437e7e72f2e988ddaa298440b687b466c84649))
+* feature C ([#12](https://github.com/dabernathy89/gf-workflow-testing/issues/12)) ([2d697ee](https://github.com/dabernathy89/gf-workflow-testing/commit/2d697eee0ac706a94e7171eebe724c388bade013))
+
 # [2.1.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.0.1...v2.1.0) (2025-08-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-workflow-test",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "private": true,
     "type": "module",
     "dependencies": {},


### PR DESCRIPTION
� Release v2.2.0

This PR contains the release branch for version 2.2.0.

## Changes
- Version bumped to 2.2.0
- Changelog updated
- Tag v2.2.0 created

## Semantic Release Output
- Version: 2.2.0
- Tag: v2.2.0
- Changelog generated

## ⚠️ Important Merge Instructions
**DO NOT use "Squash and merge"** - Use either "Create a merge commit" or "Rebase and merge" to preserve the git tag on the correct commit for production deployment.

Ready for review and merge to main.