### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [2.3.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.2.0...v2.3.0) (2025-08-05)
+
+
+### Bug Fixes
+
+* Adding fix F ([7764c85](https://github.com/dabernathy89/gf-workflow-testing/commit/7764c85aa88b45efa4f66946d44322e6a01c4bb7))
+
+
+### Features
+
+* feature g ([6f211aa](https://github.com/dabernathy89/gf-workflow-testing/commit/6f211aa7c8f6af7e9a602336014010482e2c5a71))
+* Update test.md ([3ea2e09](https://github.com/dabernathy89/gf-workflow-testing/commit/3ea2e09ff8ee173b1e5c454abc5854d37e802880))
+
 # [2.2.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.1.0...v2.2.0) (2025-08-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-workflow-test",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "private": true,
     "type": "module",
     "dependencies": {},


### PR DESCRIPTION
🚀 Release v2.3.0

This PR contains the release branch for version 2.3.0.

## Changes
- Version bumped to 2.3.0
- Changelog updated
- Tag v2.3.0 created

## Semantic Release Output
- Version: 2.3.0
- Tag: v2.3.0
- Changelog generated

## ⚠️ Important Merge Instructions
**DO NOT use "Squash and merge"** - Use only "Create a merge commit" (DO NOT use "Squash and merge" or "Rebase and merge") to preserve the git tag on the correct commit for production deployment.

Ready for review and merge to main.