### PR TITLE
Release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.7.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.6.0...v2.7.0) (2025-08-05)
+
+
+### Features
+
+* feature M ([#31](https://github.com/dabernathy89/gf-workflow-testing/issues/31)) ([f9b8547](https://github.com/dabernathy89/gf-workflow-testing/commit/f9b8547f8e1f5d897bc54af00cf85e248802bc11))
+
 # [2.6.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.5.1...v2.6.0) (2025-08-05)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-workflow-test",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "private": true,
     "type": "module",
     "dependencies": {},


### PR DESCRIPTION
🚀 Release v2.7.0

This PR contains the release branch for version 2.7.0.

## Changes
- Version bumped to 2.7.0
- Changelog updated
- Tag v2.7.0 created

## ⚠️ Important Merge Instructions
**DO NOT use "Squash and merge"** - Use only "Create a merge commit" (DO NOT use "Squash and merge" or "Rebase and merge") to preserve the git tag on the correct commit for production deployment.

Ready for review and merge to main.