### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [2.8.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.7.2...v2.8.0) (2025-08-05)
+
+
+### Bug Fixes
+
+* do some cleanup ([5fe31be](https://github.com/dabernathy89/gf-workflow-testing/commit/5fe31be1b4d62947546bb8e9a9bf5aea29f643c5))
+* fix P ([2aa0cdb](https://github.com/dabernathy89/gf-workflow-testing/commit/2aa0cdb78a6ee8d058ffa9c1fe710d606aa000d9))
+
+
+### Features
+
+* feature Q ([a3c7ab8](https://github.com/dabernathy89/gf-workflow-testing/commit/a3c7ab8cbf11836089ccd1252946fe3ddd1c69f6))
+
 ## [2.7.2](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.7.1...v2.7.2) (2025-08-05)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-workflow-test",
-            "version": "2.7.2",
+            "version": "2.8.0",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "private": true,
     "type": "module",
     "dependencies": {},


### PR DESCRIPTION
🚀 Release v2.8.0

This PR contains the release branch for version 2.8.0.

## Changes
- Version bumped to 2.8.0
- Changelog updated
- Tag v2.8.0 created

## ⚠️ Important Merge Instructions
**DO NOT use "Squash and merge"** - Use only "Create a merge commit" (DO NOT use "Squash and merge" or "Rebase and merge") to preserve the git tag on the correct commit for production deployment.

Ready for review and merge to main.