### PR TITLE
Release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [2.9.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.8.0...v2.9.0) (2025-08-05)
+
+
+### Bug Fixes
+
+* don't auto-create hotfix PR, clean up readme ([e47afa4](https://github.com/dabernathy89/gf-workflow-testing/commit/e47afa4e4a5fd5a560728c7588efed564a9d5ef5))
+
+
+### Features
+
+* feature R ([d00036a](https://github.com/dabernathy89/gf-workflow-testing/commit/d00036aaaffab8843a2d72ba97363fe9c37d5572))
+* feature S ([7827f5a](https://github.com/dabernathy89/gf-workflow-testing/commit/7827f5a64fb503368ddb9793063c2b16c0612074))
+
 # [2.8.0](https://github.com/dabernathy89/gf-workflow-testing/compare/v2.7.2...v2.8.0) (2025-08-05)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gh-workflow-test",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gh-workflow-test",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "private": true,
     "type": "module",
     "dependencies": {},


### PR DESCRIPTION
🚀 Release v2.9.0

This PR contains the release branch for version 2.9.0.

## Changes
- Version bumped to 2.9.0
- Changelog updated
- Tag v2.9.0 created

## ⚠️ Important Merge Instructions
**DO NOT use "Squash and merge"** - Use only "Create a merge commit" (DO NOT use "Squash and merge" or "Rebase and merge") to preserve the git tag on the correct commit for production deployment.

Ready for review and merge to main.